### PR TITLE
Feature/3 show error when token doesnt exist

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,6 +28,12 @@ func main() {
 		os.Exit(3)
 	}
 
+	// Default limit is 60 if no token is provided
+	if rateLimitResponse.Resources.Core.Limit == 60 {
+		utils.CautionNotice("Please provide a GitHub token to in the environment variable " + githubapi.TokenEnvName + ".")
+		os.Exit(3)
+	}
+
 	core := rateLimitResponse.Resources.Core
 	resetTime := core.Reset.Time
 	//fmt.Printf("%+v\n", core)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -96,3 +96,47 @@ func TestFetchRateLimitReached(t *testing.T) {
 		t.Errorf("Expected reset time to be in the future, got %s", core.Reset.Time)
 	}
 }
+
+func TestNoApiKeyRateLimit(t *testing.T) {
+	// Mock server to simulate GitHub API responses
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := githubapi.RateLimitResponse{
+			Resources: githubapi.RateLimit{
+				Core: githubapi.Rate{
+					Limit:     60,
+					Remaining: 59,
+					Reset:     githubapi.Timestamp{Time: time.Now().Add(30 * time.Minute)},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(response)
+		if err != nil {
+			t.Fatalf("Failed to encode JSON response: %v", err)
+		}
+	}))
+	defer mockServer.Close()
+
+	originalAPIURL := githubapi.APIURL
+	githubapi.APIURL = mockServer.URL
+	defer func() { githubapi.APIURL = originalAPIURL }()
+
+	client := &http.Client{}
+	token := ""
+
+	rateLimitResponse, err := githubapi.FetchRateLimit(client, token)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	core := rateLimitResponse.Resources.Core
+	if core.Limit != 60 {
+		t.Errorf("Expected limit to be 60, got %d", core.Limit)
+	}
+	if core.Remaining != 59 {
+		t.Errorf("Expected remaining to be 59, got %d", core.Remaining)
+	}
+	if core.Reset.Time.Before(time.Now()) {
+		t.Errorf("Expected reset time to be in the future, got %s", core.Reset.Time)
+	}
+}


### PR DESCRIPTION
Added a check to see if the return limit is 60. If so we know an API key isn't being used.